### PR TITLE
Added method to count the number of patients with clinical data

### DIFF
--- a/src/main/groovy/org/transmartproject/core/dataquery/clinical/ClinicalDataResource.groovy
+++ b/src/main/groovy/org/transmartproject/core/dataquery/clinical/ClinicalDataResource.groovy
@@ -25,4 +25,10 @@ public interface ClinicalDataResource {
     ClinicalVariable createClinicalVariable(Map<String, Object> parameters,
                                             String type) throws InvalidArgumentsException
 
+    /**
+     * Returns the number of patients from the patient set for which the system has clinical data.
+     * @param patientSet    The patientset to query.
+     * @return The number of patients from the patient set for which the system has clinical data. 
+     */
+    int getPatientCountWithClinicalData(QueryResult patientSet)
 }


### PR DESCRIPTION
This method is needed in the export process to show the user how much data he can export. See also the comments on https://github.com/thehyve/transmartApp/pull/53
